### PR TITLE
カスタムテンプレート機能を追加

### DIFF
--- a/app/controllers/admin/custom_templates_controller.rb
+++ b/app/controllers/admin/custom_templates_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Admin
+  class CustomTemplatesController < BaseController
+    before_action :set_custom_template, except: [:index, :new, :create]
+    before_action :set_filter_params
+
+    def index
+      authorize :custom_template, :index?
+      @custom_templates = filtered_custom_templates.page(params[:page])
+    end
+
+    def new
+      authorize :custom_template, :create?
+      @custom_template = CustomTemplate.new
+    end
+
+    def create
+      authorize :custom_template, :create?
+
+      @custom_template = CustomTemplate.new(resource_params)
+
+      if @custom_template.save
+        log_action :create, @custom_template
+        redirect_to admin_custom_templates_path, notice: I18n.t('admin.custom_templates.created_msg')
+      else
+        render :new
+      end
+    end
+
+    def destroy
+      authorize @custom_template, :destroy?
+      @custom_template.destroy!
+      log_action :destroy, @custom_template
+      flash[:notice] = I18n.t('admin.custom_templates.destroyed_msg')
+      redirect_to admin_custom_templates_path(page: params[:page], **@filter_params)
+    end
+
+    def enable
+      authorize @custom_template, :enable?
+      @custom_template.update!(disabled: false)
+      log_action :enable, @custom_template
+      flash[:notice] = I18n.t('admin.custom_templates.enabled_msg')
+      redirect_to admin_custom_templates_path(page: params[:page], **@filter_params)
+    end
+
+    def disable
+      authorize @custom_template, :disable?
+      @custom_template.update!(disabled: true)
+      log_action :disable, @custom_template
+      flash[:notice] = I18n.t('admin.custom_templates.disabled_msg')
+      redirect_to admin_custom_templates_path(page: params[:page], **@filter_params)
+    end
+
+    private
+
+    def set_custom_template
+      @custom_template = CustomTemplate.find(params[:id])
+    end
+
+    def set_filter_params
+      @filter_params = filter_params.to_hash.symbolize_keys
+    end
+
+    def resource_params
+      params.require(:custom_template).permit(:content)
+    end
+
+    def filtered_custom_templates
+      CustomTemplateFilter.new(filter_params).results
+    end
+
+    def filter_params
+      params.permit(
+        :content
+      )
+    end
+  end
+end
+

--- a/app/controllers/api/v1/custom_templates_controller.rb
+++ b/app/controllers/api/v1/custom_templates_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Api::V1::CustomTemplatesController < Api::BaseController
+  respond_to :json
+
+  def index
+    render json: CustomTemplate.where(disabled: false), each_serializer: REST::CustomTemplateSerializer
+  end
+end

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -46,6 +46,8 @@ export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
 
 export const COMPOSE_EMOJI_INSERT = 'COMPOSE_EMOJI_INSERT';
 
+export const COMPOSE_TEMPLATE_INSERT = 'COMPOSE_TEMPLATE_INSERT';
+
 export const COMPOSE_UPLOAD_CHANGE_REQUEST     = 'COMPOSE_UPLOAD_UPDATE_REQUEST';
 export const COMPOSE_UPLOAD_CHANGE_SUCCESS     = 'COMPOSE_UPLOAD_UPDATE_SUCCESS';
 export const COMPOSE_UPLOAD_CHANGE_FAIL        = 'COMPOSE_UPLOAD_UPDATE_FAIL';
@@ -471,6 +473,14 @@ export function insertEmojiCompose(position, emoji, needsSpace) {
     position,
     emoji,
     needsSpace,
+  };
+};
+
+export function insertTemplateCompose(position, template) {
+  return {
+    type: COMPOSE_TEMPLATE_INSERT,
+    position,
+    template,
   };
 };
 

--- a/app/javascript/mastodon/actions/custom_templates.js
+++ b/app/javascript/mastodon/actions/custom_templates.js
@@ -1,0 +1,37 @@
+import api from '../api';
+
+export const CUSTOM_TEMPLATES_FETCH_REQUEST = 'CUSTOM_TEMPLATES_FETCH_REQUEST';
+export const CUSTOM_TEMPLATES_FETCH_SUCCESS = 'CUSTOM_TEMPLATES_FETCH_SUCCESS';
+export const CUSTOM_TEMPLATES_FETCH_FAIL = 'CUSTOM_TEMPLATES_FETCH_FAIL';
+
+export function fetchCustomTemplates() {
+  return (dispatch, getState) => {
+    dispatch(fetchCustomTemplatesRequest());
+
+    api(getState).get('/api/v1/custom_templates').then(response => {
+      dispatch(fetchCustomTemplatesSuccess(response.data));
+    }).catch(error => {
+      dispatch(fetchCustomTemplatesFail(error));
+    });
+  };
+}
+
+export function fetchCustomTemplatesRequest() {
+  return {
+    type: CUSTOM_TEMPLATES_FETCH_REQUEST,
+  };
+}
+
+export function fetchCustomTemplatesSuccess(custom_templates) {
+  return {
+    type: CUSTOM_TEMPLATES_FETCH_SUCCESS,
+    custom_templates,
+  };
+}
+
+export function fetchCustomTemplatesFail(error) {
+  return {
+    type: CUSTOM_TEMPLATES_FETCH_FAIL,
+    error,
+  };
+}

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -7,6 +7,7 @@ import { BrowserRouter, Route } from 'react-router-dom';
 import { ScrollContext } from 'react-router-scroll-4';
 import UI from '../features/ui';
 import { fetchCustomEmojis } from '../actions/custom_emojis';
+import { fetchCustomTemplates } from '../actions/custom_templates';
 import { hydrateStore } from '../actions/store';
 import { connectUserStream } from '../actions/streaming';
 import { IntlProvider, addLocaleData } from 'react-intl';
@@ -22,6 +23,9 @@ store.dispatch(hydrateAction);
 
 // load custom emojis
 store.dispatch(fetchCustomEmojis());
+
+// load custom templates
+store.dispatch(fetchCustomTemplates());
 
 export default class Mastodon extends React.PureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -11,6 +11,7 @@ import SpoilerButtonContainer from '../containers/spoiler_button_container';
 import PrivacyDropdownContainer from '../containers/privacy_dropdown_container';
 import SensitiveButtonContainer from '../containers/sensitive_button_container';
 import EmojiPickerDropdown from '../containers/emoji_picker_dropdown_container';
+import TemplatePickerDropdown from '../containers/template_picker_dropdown_container';
 import UploadFormContainer from '../containers/upload_form_container';
 import WarningContainer from '../containers/warning_container';
 import { isMobile } from '../../../is_mobile';
@@ -51,6 +52,7 @@ export default class ComposeForm extends ImmutablePureComponent {
     onChangeSpoilerText: PropTypes.func.isRequired,
     onPaste: PropTypes.func.isRequired,
     onPickEmoji: PropTypes.func.isRequired,
+    onPickTemplate: PropTypes.func.isRequired,
     showSearch: PropTypes.bool,
     anyMedia: PropTypes.bool,
   };
@@ -152,6 +154,12 @@ export default class ComposeForm extends ImmutablePureComponent {
     this.props.onPickEmoji(position, data, needsSpace);
   }
 
+  handleTemplatePick = (data) => {
+    const position  = this.autosuggestTextarea.textarea.selectionStart;
+
+    this.props.onPickTemplate(position, data);
+  }
+
   render () {
     const { intl, onPaste, showSearch, anyMedia } = this.props;
     const disabled = this.props.is_submitting;
@@ -195,6 +203,7 @@ export default class ComposeForm extends ImmutablePureComponent {
           />
 
           <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
+          <TemplatePickerDropdown onPickTemplate={this.handleTemplatePick} />
         </div>
 
         <div className='compose-form__modifiers'>

--- a/app/javascript/mastodon/features/compose/components/template_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/template_picker_dropdown.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, injectIntl } from 'react-intl';
+import Overlay from 'react-overlays/lib/Overlay';
+import emojify from '../../emoji/emoji';
+import classNames from 'classnames';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import detectPassiveEvents from 'detect-passive-events';
+import escapeTextContentForBrowser from 'escape-html';
+
+const messages = defineMessages({
+  template: { id: 'template_button.label', defaultMessage: 'Insert template' },
+
+});
+
+const assetHost = process.env.CDN_HOST || '';
+
+const listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
+
+@injectIntl
+class TemplatePicker extends React.PureComponent {
+
+  static propTypes = {
+    custom_templates: ImmutablePropTypes.list,
+    intl: PropTypes.object.isRequired,
+    onClick: PropTypes.func.isRequired,
+  };
+
+  handleClick = e => {
+    const { custom_templates, onClick } = this.props;
+    onClick(custom_templates.get(e.currentTarget.getAttribute('data-index')));
+  }
+
+  render () {
+    const { custom_templates, intl } = this.props;
+    const { handleClick } = this;
+    const title = intl.formatMessage(messages.template);
+
+    return (
+      <div className='template-picker'>
+        <div className='template-picker-title'>{title}</div>
+        <div className='template-picker-scroll'>
+          {custom_templates.map((template, i) => {
+            const content = template.get('content');
+            const emojis = template.get('emojis').toJS().reduce((map, emoji) => {
+              map[`:${emoji.shortcode}:`] = emoji;
+              return map;
+            }, {});
+
+            const html = emojify(escapeTextContentForBrowser(content).replace(/\n/g, '<br />'), emojis);
+
+            return (
+              <div
+                className='template-picker-template'
+                key={i}
+                data-index={i}
+                dangerouslySetInnerHTML={{ __html: html }}
+                onClick={handleClick}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}
+
+@injectIntl
+class TemplatePickerMenu extends React.PureComponent {
+
+  static propTypes = {
+    custom_templates: ImmutablePropTypes.list,
+    style: PropTypes.object,
+    onPick: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
+  };
+
+  state = {
+    placement: null,
+  };
+
+  handleDocumentClick = e => {
+    if (this.node && !this.node.contains(e.target)) {
+      this.props.onClose();
+    }
+  }
+
+  componentDidMount () {
+    document.addEventListener('click', this.handleDocumentClick, false);
+    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('click', this.handleDocumentClick, false);
+    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  }
+
+  setRef = c => {
+    this.node = c;
+  }
+
+  handleClick = template => {
+    this.props.onClose();
+    this.props.onPick(template);
+  }
+
+  render () {
+    const { style } = this.props;
+
+    return (
+      <div className='template-picker-dropdown__menu' style={style} ref={this.setRef}>
+        <TemplatePicker
+          custom_templates={this.props.custom_templates}
+          onClick={this.handleClick}
+        />
+      </div>
+    );
+  }
+}
+
+@injectIntl
+export default class TemplatePickerDropdown extends React.PureComponent {
+
+  static propTypes = {
+    custom_templates: ImmutablePropTypes.list,
+    intl: PropTypes.object.isRequired,
+    onPickTemplate: PropTypes.func.isRequired,
+  };
+
+  state = {
+    active: false,
+  };
+
+  setRef = (c) => {
+    this.dropdown = c;
+  }
+
+  onShowDropdown = ({ target }) => {
+    this.setState({ active: true });
+
+    const { top } = target.getBoundingClientRect();
+    this.setState({ placement: top * 2 < innerHeight ? 'bottom' : 'top' });
+  }
+
+  onHideDropdown = () => {
+    this.setState({ active: false });
+  }
+
+  onToggle = (e) => {
+    if (!e.key || e.key === 'Enter') {
+      if (this.state.active) {
+        this.onHideDropdown();
+      } else {
+        this.onShowDropdown(e);
+      }
+    }
+  }
+
+  handleKeyDown = e => {
+    if (e.key === 'Escape') {
+      this.onHideDropdown();
+    }
+  }
+
+  setTargetRef = c => {
+    this.target = c;
+  }
+
+  findTarget = () => {
+    return this.target;
+  }
+
+  render () {
+    const { intl, onPickTemplate } = this.props;
+    const title = intl.formatMessage(messages.template);
+    const { active, placement } = this.state;
+
+    return (
+      <div className='template-picker-dropdown' onKeyDown={this.handleKeyDown}>
+        <div ref={this.setTargetRef} className='emoji-button' title={title} aria-label={title} aria-expanded={active} role='button' onClick={this.onToggle} onKeyDown={this.onToggle} tabIndex={0}>
+          <img
+            className='emojione'
+            alt='📋'
+            src={`${assetHost}/emoji/1f4cb.svg`}
+          />
+        </div>
+
+        <Overlay show={active} placement={placement} target={this.findTarget}>
+          <TemplatePickerMenu
+            custom_templates={this.props.custom_templates}
+            onPick={onPickTemplate}
+            onClose={this.onHideDropdown}
+          />
+        </Overlay>
+      </div>
+    );
+  }
+}

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -9,6 +9,7 @@ import {
   selectComposeSuggestion,
   changeComposeSpoilerText,
   insertEmojiCompose,
+  insertTemplateCompose,
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
@@ -59,6 +60,10 @@ const mapDispatchToProps = (dispatch) => ({
 
   onPickEmoji (position, data, needsSpace) {
     dispatch(insertEmojiCompose(position, data, needsSpace));
+  },
+
+  onPickTemplate (position, data) {
+    dispatch(insertTemplateCompose(position, data));
   },
 
 });

--- a/app/javascript/mastodon/features/compose/containers/template_picker_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/template_picker_dropdown_container.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import TemplatePickerDropdown from '../components/template_picker_dropdown';
+
+const mapStateToProps = state => ({
+  custom_templates: state.get('custom_templates'),
+});
+
+const mapDispatchToProps = (dispatch, { onPickTemplate }) => ({
+  onPickTemplate: template => {
+    onPickTemplate(template.get('content'));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TemplatePickerDropdown);

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -316,6 +316,7 @@
   "tabs_bar.local_timeline": "Local",
   "tabs_bar.notifications": "Notifications",
   "tabs_bar.search": "Search",
+  "template_button.label": "Add from template",
   "trends.count_by_accounts": "{count} {rawCount, plural, one {person} other {people}} talking",
   "ui.beforeunload": "Your draft will be lost if you leave Mastodon.",
   "upload_area.title": "Drag & drop to upload",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -316,6 +316,7 @@
   "tabs_bar.local_timeline": "ローカル",
   "tabs_bar.notifications": "通知",
   "tabs_bar.search": "検索",
+  "template_button.label": "テンプレートから追加",
   "trends.count_by_accounts": "{count} {rawCount, plural, one {人} other {人}} がトゥート",
   "ui.beforeunload": "Mastodonから離れると送信前の投稿は失われます。",
   "upload_area.title": "ドラッグ＆ドロップでアップロード",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -25,6 +25,7 @@ import {
   COMPOSE_VISIBILITY_CHANGE,
   COMPOSE_COMPOSING_CHANGE,
   COMPOSE_EMOJI_INSERT,
+  COMPOSE_TEMPLATE_INSERT,
   COMPOSE_UPLOAD_CHANGE_REQUEST,
   COMPOSE_UPLOAD_CHANGE_SUCCESS,
   COMPOSE_UPLOAD_CHANGE_FAIL,
@@ -154,6 +155,17 @@ const insertEmoji = (state, position, emojiData, needsSpace) => {
     text: `${oldText.slice(0, position)}${emoji} ${oldText.slice(position)}`,
     focusDate: new Date(),
     caretPosition: position + emoji.length + 1,
+    idempotencyKey: uuid(),
+  });
+};
+
+const insertTemplate = (state, position, templateData) => {
+  const oldText = state.get('text');
+
+  return state.merge({
+    text: `${oldText.slice(0, position)}${templateData}${oldText.slice(position)}`,
+    focusDate: new Date(),
+    caretPosition: position + templateData.length,
     idempotencyKey: uuid(),
   });
 };
@@ -309,6 +321,8 @@ export default function compose(state = initialState, action) {
     }
   case COMPOSE_EMOJI_INSERT:
     return insertEmoji(state, action.position, action.emoji, action.needsSpace);
+  case COMPOSE_TEMPLATE_INSERT:
+    return insertTemplate(state, action.position, action.template);
   case COMPOSE_UPLOAD_CHANGE_SUCCESS:
     return state
       .set('is_submitting', false)

--- a/app/javascript/mastodon/reducers/custom_templates.js
+++ b/app/javascript/mastodon/reducers/custom_templates.js
@@ -1,0 +1,12 @@
+import { List as ImmutableList, fromJS as ConvertToImmutable } from 'immutable';
+import { CUSTOM_TEMPLATES_FETCH_SUCCESS } from '../actions/custom_templates';
+
+const initialState = ImmutableList([]);
+
+export default function custom_templates(state = initialState, action) {
+  if (action.type === CUSTOM_TEMPLATES_FETCH_SUCCESS) {
+    state = ConvertToImmutable(action.custom_templates);
+  }
+
+  return state;
+};

--- a/app/javascript/mastodon/reducers/index.js
+++ b/app/javascript/mastodon/reducers/index.js
@@ -24,6 +24,7 @@ import media_attachments from './media_attachments';
 import notifications from './notifications';
 import height_cache from './height_cache';
 import custom_emojis from './custom_emojis';
+import custom_templates from './custom_templates';
 import lists from './lists';
 import listEditor from './list_editor';
 import filters from './filters';
@@ -54,6 +55,7 @@ const reducers = {
   notifications,
   height_cache,
   custom_emojis,
+  custom_templates,
   lists,
   listEditor,
   filters,

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -221,6 +221,14 @@
       padding-top: 20px;
     }
   }
+
+  .custom-template-emoji {
+    line-height: 1;
+
+    .emojione {
+      margin: 0;
+    }
+  }
 }
 
 .filters {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -301,6 +301,12 @@
       right: 5px;
       top: 5px;
     }
+
+    .template-picker-dropdown {
+      position: absolute;
+      right: 5px;
+      top: 32px;
+    }
   }
 
   .autosuggest-textarea,
@@ -3123,6 +3129,7 @@ a.status-card {
   animation: shake-bottom 0.8s cubic-bezier(0.455, 0.030, 0.515, 0.955) 2s 2 both;
 }
 
+.template-picker-dropdown__menu,
 .emoji-picker-dropdown__menu {
   background: $simple-background-color;
   position: absolute;
@@ -3406,6 +3413,41 @@ a.status-card {
   .privacy-dropdown__dropdown {
     display: block;
     box-shadow: 2px 4px 6px rgba($base-shadow-color, 0.1);
+  }
+}
+
+.template-picker {
+  width: 300px;
+  background: #ffffff;
+  color: #282c37;
+  border-radius: 4px;
+
+  .template-picker-title {
+    padding: 6px 12px;
+  }
+
+  .template-picker-scroll {
+    overflow-y: scroll;
+    height: 300px;
+    padding: 0 6px;
+
+    .template-picker-template {
+      line-height: 1;
+      padding: 6px;
+      position: relative;
+      cursor: pointer;
+
+      &:hover {
+        background-color: rgba(217, 225, 232, .7);
+        border-radius: 4px;
+      }
+
+      .emojione {
+        margin: 0;
+        width: 24px;
+        height: 24px;
+      }
+    }
   }
 }
 

--- a/app/models/custom_template.rb
+++ b/app/models/custom_template.rb
@@ -12,4 +12,25 @@
 class CustomTemplate < ApplicationRecord
   scope :alphabetic, -> { order(content: :asc) }
 
+  def preview
+    emojis = CustomEmoji.from_text(content, nil)
+    position = 0
+    codes = []
+
+    while (m = content.match(CustomEmoji::SCAN_RE, position))
+      codes << content[position..m.begin(0) - 1] if m.begin(0) > 0
+
+      emoji = emojis.detect { |e| e.shortcode == m[1] }
+      if emoji
+        codes << emoji
+      else
+        codes << content[m.begin(0)..m.end(0)]
+      end
+
+      position = m.end(0)
+    end
+
+    codes << content[position..-1]
+    codes
+  end
 end

--- a/app/models/custom_template.rb
+++ b/app/models/custom_template.rb
@@ -12,15 +12,19 @@
 class CustomTemplate < ApplicationRecord
   scope :alphabetic, -> { order(content: :asc) }
 
+  def emojis
+    CustomEmoji.from_text(content, nil)
+  end
+
   def preview
-    emojis = CustomEmoji.from_text(content, nil)
+    emojis = self.emojis
     position = 0
     codes = []
 
     while (m = content.match(CustomEmoji::SCAN_RE, position))
       codes << content[position..m.begin(0) - 1] if m.begin(0) > 0
 
-      emoji = emojis.detect { |e| e.shortcode == m[1] }
+      emoji = emojis.find { |e| e.shortcode == m[1] }
       if emoji
         codes << emoji
       else

--- a/app/models/custom_template.rb
+++ b/app/models/custom_template.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: custom_templates
+#
+#  id         :bigint(8)        not null, primary key
+#  content    :text             not null
+#  disabled   :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class CustomTemplate < ApplicationRecord
+  scope :alphabetic, -> { order(content: :asc) }
+
+end

--- a/app/models/custom_template_filter.rb
+++ b/app/models/custom_template_filter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CustomTemplateFilter
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+
+  def results
+    CustomTemplate.alphabetic
+  end
+end

--- a/app/policies/custom_template_policy.rb
+++ b/app/policies/custom_template_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CustomTemplatePolicy < ApplicationPolicy
+  def index?
+    staff?
+  end
+
+  def create?
+    admin?
+  end
+
+  def enable?
+    staff?
+  end
+
+  def disable?
+    staff?
+  end
+
+  def destroy?
+    admin?
+  end
+end

--- a/app/serializers/rest/custom_template_serializer.rb
+++ b/app/serializers/rest/custom_template_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class REST::CustomTemplateSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :content
+  has_many :emojis, serializer: REST::CustomEmojiSerializer
+end

--- a/app/views/admin/custom_templates/_custom_template.html.haml
+++ b/app/views/admin/custom_templates/_custom_template.html.haml
@@ -1,4 +1,10 @@
 %tr
+  %td.custom-template-emoji<
+    - custom_template.preview.each do |item|
+      - if item.is_a?(CustomEmoji)
+        = custom_emoji_tag(item)
+      - else
+        = safe_join(item.split("\r"), tag(:br))
   %td
     %samp= simple_format(custom_template.content)
   %td

--- a/app/views/admin/custom_templates/_custom_template.html.haml
+++ b/app/views/admin/custom_templates/_custom_template.html.haml
@@ -1,0 +1,10 @@
+%tr
+  %td
+    %samp= simple_format(custom_template.content)
+  %td
+    - if custom_template.disabled?
+      = table_link_to 'power-off', t('admin.custom_templates.enable'), enable_admin_custom_template_path(custom_template, page: params[:page], **@filter_params), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }
+    - else
+      = table_link_to 'power-off', t('admin.custom_templates.disable'), disable_admin_custom_template_path(custom_template, page: params[:page], **@filter_params), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }
+  %td
+    = table_link_to 'times', t('admin.custom_templates.delete'), admin_custom_template_path(custom_template, page: params[:page], **@filter_params), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') }

--- a/app/views/admin/custom_templates/index.html.haml
+++ b/app/views/admin/custom_templates/index.html.haml
@@ -1,0 +1,13 @@
+- content_for :page_title do
+  = t('admin.custom_templates.title')
+
+.table-wrapper
+  %table.table
+    %thead
+      %tr
+        %th= t('admin.custom_templates.content')
+    %tbody
+      = render @custom_templates
+
+= paginate @custom_templates
+= link_to t('admin.custom_templates.add_new'), new_admin_custom_template_path, class: 'button'

--- a/app/views/admin/custom_templates/index.html.haml
+++ b/app/views/admin/custom_templates/index.html.haml
@@ -5,6 +5,7 @@
   %table.table
     %thead
       %tr
+        %th= t('admin.custom_templates.preview')
         %th= t('admin.custom_templates.content')
     %tbody
       = render @custom_templates

--- a/app/views/admin/custom_templates/new.html.haml
+++ b/app/views/admin/custom_templates/new.html.haml
@@ -1,0 +1,11 @@
+- content_for :page_title do
+  = t('.title')
+
+= simple_form_for @custom_template, url: admin_custom_templates_path do |f|
+  = render 'shared/error_messages', object: @custom_template
+
+  .fields-group
+    = f.input :content, wrapper: :with_block_label, as: :text, label: t('admin.custom_templates.content'), input_html: { rows: 4 }
+
+  .actions
+    = f.button :button, t('admin.custom_templates.add_new'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,20 @@ en:
       update_failed_msg: Could not update that emoji
       updated_msg: Emoji successfully updated!
       upload: Upload
+    custom_templates:
+      add_new: Add new
+      content: Content
+      created_msg: Template successfully created!
+      delete: Delete
+      destroyed_msg: Template Successfully destroyed!
+      disable: Disable
+      disabled_msg: Successfully disabled that template
+      enable: Enable
+      enabled_msg: Successfully enabled that template
+      new:
+        title: Add new custom template
+      preview: Preview
+      title: Custom templates
     dashboard:
       backlog: backlogged jobs
       config: Configuration

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -229,7 +229,6 @@ ja:
       destroyed_msg: テンプレートの削除に成功しました！
       disable: 無効化
       disabled_msg: テンプレートを無効化しました
-      disable: 無効化
       enable: 有効化
       enabled_msg: テンプレートを有効化しました
       new:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -221,6 +221,20 @@ ja:
       update_failed_msg: 絵文字を更新できませんでした
       updated_msg: 絵文字の更新に成功しました！
       upload: アップロード
+    custom_templates:
+      add_new: 新規追加
+      content: 内容
+      created_msg: テンプレートの追加に成功しました！
+      delete: 削除
+      destroyed_msg: テンプレートの削除に成功しました！
+      disable: 無効化
+      disabled_msg: テンプレートを無効化しました
+      disable: 無効化
+      enable: 有効化
+      enabled_msg: テンプレートを有効化しました
+      new:
+        title: 新規カスタムテンプレートの追加
+      title: カスタムテンプレート
     dashboard:
       backlog: 未処理のジョブ
       config: 構成

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -234,6 +234,7 @@ ja:
       enabled_msg: テンプレートを有効化しました
       new:
         title: 新規カスタムテンプレートの追加
+      preview: プレビュー
       title: カスタムテンプレート
     dashboard:
       backlog: 未処理のジョブ

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -37,6 +37,7 @@ SimpleNavigation::Configuration.run do |navigation|
       admin.item :dashboard, safe_join([fa_icon('tachometer fw'), t('admin.dashboard.title')]), admin_dashboard_url
       admin.item :settings, safe_join([fa_icon('cogs fw'), t('admin.settings.title')]), edit_admin_settings_url, if: -> { current_user.admin? }
       admin.item :custom_emojis, safe_join([fa_icon('smile-o fw'), t('admin.custom_emojis.title')]), admin_custom_emojis_url, highlights_on: %r{/admin/custom_emojis}
+      admin.item :custom_templates, safe_join([fa_icon('picture-o fw'), t('admin.custom_templates.title')]), admin_custom_templates_url, highlights_on: %r{/admin/custom_templates}
       admin.item :relays, safe_join([fa_icon('exchange fw'), t('admin.relays.title')]), admin_relays_url, if: -> { current_user.admin? }, highlights_on: %r{/admin/relays}
       admin.item :subscriptions, safe_join([fa_icon('paper-plane-o fw'), t('admin.subscriptions.title')]), admin_subscriptions_url, if: -> { current_user.admin? }
       admin.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_url, link_html: { target: 'sidekiq' }, if: -> { current_user.admin? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :custom_templates, only: [:index, :new, :create, :update, :destroy] do
+      member do
+        post :enable
+        post :disable
+      end
+    end
+
     resources :account_moderation_notes, only: [:create, :destroy]
   end
 
@@ -259,6 +266,7 @@ Rails.application.routes.draw do
 
       resources :streaming, only: [:index]
       resources :custom_emojis, only: [:index]
+      resources :custom_templates, only: [:index]
       resources :suggestions, only: [:index, :destroy]
 
       get '/search', to: 'search#index', as: :search

--- a/db/migrate/20180915133916_create_custom_templates.rb
+++ b/db/migrate/20180915133916_create_custom_templates.rb
@@ -1,0 +1,10 @@
+class CreateCustomTemplates < ActiveRecord::Migration[5.2]
+  def change
+    create_table :custom_templates do |t|
+      t.text :content, null: false
+      t.boolean :disabled, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_20_232245) do
+ActiveRecord::Schema.define(version: 2018_09_15_133916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,6 +165,13 @@ ActiveRecord::Schema.define(version: 2018_08_20_232245) do
     t.datetime "updated_at", null: false
     t.boolean "whole_word", default: true, null: false
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
+  end
+
+  create_table "custom_templates", force: :cascade do |t|
+    t.text "content", null: false
+    t.boolean "disabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "domain_blocks", force: :cascade do |t|


### PR DESCRIPTION
## API

- /api/v1/custom_templates の追加

## 管理画面

- /admin/custom_templates の追加

## フロント

- [テンプレートから追加] ボタンの追加

<img src="https://user-images.githubusercontent.com/6535425/45598188-c90c3c00-ba12-11e8-88a0-a8c01bfc36c8.gif" alt="" width="960">

