### PR TITLE
Fix emoji spacing in template picker

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4304,6 +4304,7 @@ a.status-card.compact:hover {
           margin: 0;
           width: 24px;
           height: 24px;
+          object-fit: initial;
         }
       }
     }


### PR DESCRIPTION
## 「テンプレートから追加」画面の絵文字の表示の余白を修正

「ゆゆ式」の部分に注目 👀 

### 修正前
<img width="440" alt="" src="https://user-images.githubusercontent.com/6535425/85892537-15adb980-b82c-11ea-8350-dc54aed5f84a.png">

### 修正後
<img width="440" alt="" src="https://user-images.githubusercontent.com/6535425/85892545-18a8aa00-b82c-11ea-8d7c-1557128b6222.png">
