### PR TITLE
Fix navigation being disabled in media modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -75,6 +75,9 @@ class MediaModal extends ImmutablePureComponent {
   }
 
   handleKeyDown = (e) => {
+    if (e.altKey) {
+      return
+    }
     switch(e.key) {
     case 'ArrowLeft':
       this.handlePrevClick();


### PR DESCRIPTION
Alt＋←/→の場合はメディアの切り替えを実行しないように修正しました。これによってブラウザーの戻る/進むのイベントが抑制されなくなります！