### PR TITLE
Use the same background color as emoji for Emoji template

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5581,7 +5581,7 @@ a.status-card {
         width: calc(100% / 2 - 12px);
 
         &:hover {
-          background-color: rgba(217, 225, 232, .7);
+          background-color: var(--dropdown-border-color);
           border-radius: 4px;
         }
 


### PR DESCRIPTION
テンプレートピッカー内の各テンプレートのホバー時の背景色を絵文字のものとそろえました。

関連
https://github.com/gomasy/mastodon/commit/6936e5aa693ccc4aabd26ef18a65fbb8132f6f74#diff-4dfbb8880f23026ab159a56844c28b955b884bb52b4d25623d22e61960c5be03